### PR TITLE
feat(domain): add Arete studio operator skill pack + executive brief

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ cd ai-skills
 # Install a curated bundle
 ./tools/install.sh --bundle webapp-security
 
+# Install the Arete studio operator pack
+./tools/install.sh --bundle arete-studio-ops
+
 # Install everything
 ./tools/install.sh --all
 
@@ -35,6 +38,16 @@ cd ai-skills
 ```
 
 **See it in action:** Ask Claude to review a function with SQL injection — with the skill loaded, you get severity-ranked findings with line references and concrete fixes instead of vague suggestions.
+
+## Arete Studio Pack
+
+Use the `arete-studio-ops` bundle for research-driven strategy and agentic execution loops:
+
+```bash
+./tools/install.sh --bundle arete-studio-ops
+```
+
+Executive brief for this pack: [ARETE_STUDIO_EXECUTIVE_SUMMARY_2026-05-30.md](docs/arete/ARETE_STUDIO_EXECUTIVE_SUMMARY_2026-05-30.md)
 
 ### Hello World: Create Your Own Skill in 60 Seconds
 

--- a/bundles.yaml
+++ b/bundles.yaml
@@ -146,3 +146,15 @@ bundles:
       - workflows/session-start
       - workflows/session-end
       - workflows/context-mapping
+
+  arete-studio-ops:
+    description: Arete studio operating pack - research harvest, strategy orchestration, and funding narrative
+    audience: Solo founders and small teams running agentic execution loops
+    skills:
+      - personas/domain/arete-research-command-center
+      - personas/domain/arete-studio-strategy-os
+      - personas/domain/arete-funding-value-brief
+      - personas/domain/strategic-planner
+      - personas/engineering/composite-scorer
+      - workflows/session-start
+      - workflows/session-end

--- a/docs/arete/ARETE_STUDIO_EXECUTIVE_SUMMARY_2026-05-30.md
+++ b/docs/arete/ARETE_STUDIO_EXECUTIVE_SUMMARY_2026-05-30.md
@@ -1,0 +1,126 @@
+# Arete Studio Executive Summary (2026-05-30)
+
+## Purpose
+
+Define how Arete uses AI tools, research intelligence, and reusable skills to improve business outcomes, operating quality, and future strategy.
+
+## Strategic Thesis
+
+Arete should run as an intelligence-to-execution studio:
+
+1. Ingest high-signal research weekly.
+2. Convert insights into small, testable experiments.
+3. Productize winning workflows into reusable skills.
+4. Use proof artifacts to strengthen brand, revenue, and funding position.
+
+The edge is not access to models. The edge is compounding process quality.
+
+## Skill Pack Added for This Mission
+
+- `arete-research-command-center`
+- `arete-studio-strategy-os`
+- `arete-funding-value-brief`
+
+These skills combine with existing ones to form a full operating loop for planning, execution, measurement, and capital narrative.
+
+## Operating Model
+
+### Weekly Loop
+
+- Monday: run research harvest and pick one objective.
+- Tuesday-Thursday: execute 1-3 experiments with artifact outputs.
+- Friday: keep/kill/pivot based on evidence and metrics.
+
+### Monthly Loop
+
+- Upgrade one recurring task into reusable skill/template.
+- Audit quality, rework rate, and throughput.
+- Prune low-signal activity and tool sprawl.
+
+### Quarterly Loop
+
+- Reassess ICP, wedge, and strategic positioning.
+- Refresh milestone and funding narrative from new proof.
+- Reallocate effort to highest leverage lanes.
+
+## AI Strategy Pillars
+
+1. Workflow compounding
+- Convert repetition into reusable skills and templates.
+
+2. Evidence-first execution
+- Link strategy claims to measurable outputs.
+
+3. Multi-model pragmatism
+- Pick tools/models by job, not loyalty.
+
+4. Eval-driven quality
+- Use rubric and eval checks to prevent drift.
+
+## Tool and Workflow Blueprint
+
+1. Signal intake
+- Use `arete-research-command-center` and `moonshot-arete-harvester`.
+
+2. Strategy and prioritization
+- Use `arete-studio-strategy-os`.
+
+3. Execution
+- Use `founder-sprint-planner`, `founder-execution-os`, and `solo-founder-agent-stack`.
+
+4. Funding and value narrative
+- Use `arete-funding-value-brief`.
+
+5. Quality controls
+- Add dataset/eval checkpoints for recurring outputs.
+
+## 90-Day Plan
+
+### Days 1-30
+
+- Establish weekly research-to-experiment rhythm.
+- Define baseline metrics: throughput, quality, leverage, response.
+- Ship at least two reusable skill/process upgrades.
+
+### Days 31-60
+
+- Expand automation for high-frequency tasks.
+- Increase proof artifact production (case studies, demos, metrics).
+- Reduce rework through rubric tightening.
+
+### Days 61-90
+
+- Consolidate results into investor-ready narrative.
+- Choose scale path: double down or pivot based on evidence.
+- Formalize next-quarter capital and growth plan.
+
+## Risks and Mitigations
+
+- Insight overload without execution focus
+  - Mitigation: cap active priorities and enforce weekly objective discipline.
+
+- Tool sprawl and fragile workflows
+  - Mitigation: standardize to a small core stack and measurable outputs.
+
+- Automation quality drift
+  - Mitigation: introduce eval checkpoints and manual quality gates.
+
+- Internal velocity with weak external signal
+  - Mitigation: require market-facing artifacts each cycle.
+
+## Success Criteria
+
+By 90 days, Arete should show:
+
+- Faster research-to-action cycle time.
+- Higher output throughput with stable quality.
+- Durable library of reusable agentic skills.
+- Clear evidence trail supporting brand and funding goals.
+
+## External References Used
+
+- Moonshots with Peter Diamandis
+- OpenAI Podcast
+- OpenAI Academy resources
+- Claude Code skills documentation
+- OpenAI docs: agents, tools/MCP connectors, file search, eval workflows

--- a/personas/domain/arete-funding-value-brief/SKILL.md
+++ b/personas/domain/arete-funding-value-brief/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: arete-funding-value-brief
+version: "2.0.0"
+type: persona
+category: domain
+risk_level: low
+description: Converts Arete execution signals into investor-grade funding narratives, milestone proofs, and de-risking plans.
+metadata: {"openclaw": {"emoji": "💼", "os": ["darwin", "linux", "win32"]}}
+user-invocable: true
+---
+
+# Arete Funding Value Brief
+
+## Role
+
+You are Arete's funding narrative specialist. You translate execution evidence into clear value-creation logic and milestone-based capital planning.
+
+## When to Use
+
+Use this skill when:
+- Preparing investor updates, memos, or raise narratives
+- Translating workflow outcomes into business value
+- Building milestone proof chains for de-risking
+- Prioritizing use-of-funds decisions
+
+## When NOT to Use
+
+Do NOT use this skill when:
+- No evidence exists yet - first run strategy and execution workflows
+- You need tactical coding work - use engineering skills
+- You need only raw source synthesis - use research command center
+
+## Core Behaviors
+
+**Always:**
+- Start with the wedge: urgent pain + specific buyer
+- Define compounding mechanism: speed, cost, distribution, data, or quality
+- Map proofs by horizon: 30, 90, and 365 days
+- Tie capital ask to de-risked milestones, not generic headcount
+- Include explicit risk register and fallback plan
+
+**Never:**
+- Make claims without evidence or named experiments
+- Present use-of-funds without expected outcome
+- Ignore model/platform dependency risks
+
+## Output Format
+
+```markdown
+## Investment Thesis
+## Value Creation Model
+## Milestone Proof Roadmap (30/90/365)
+## Capital Plan and Use of Funds
+## Key Risks and Mitigations
+## Next Investor Conversations
+```
+
+## Constraints
+
+- Prefer numbers over adjectives.
+- Keep narrative concise and decision-ready.
+- Every claim should point to current evidence or planned test.
+
+## References
+
+- [investor-brief-template.md](references/investor-brief-template.md)

--- a/personas/domain/arete-funding-value-brief/references/investor-brief-template.md
+++ b/personas/domain/arete-funding-value-brief/references/investor-brief-template.md
@@ -1,0 +1,38 @@
+# Investor Brief Template
+
+## 1) Thesis
+
+- Problem:
+- Why now:
+- Why this team:
+- Why this wedge wins:
+
+## 2) Value Model
+
+- Value created for customer:
+- Value captured by business:
+- Compounding loop:
+
+## 3) Milestone Roadmap
+
+| Horizon | Milestone | Proof artifact | De-risked question |
+| --- | --- | --- | --- |
+| 30 days |  |  |  |
+| 90 days |  |  |  |
+| 365 days |  |  |  |
+
+## 4) Capital Plan
+
+- Raise target:
+- Runway objective:
+- Use of funds by milestone:
+  1. 
+  2. 
+  3. 
+
+## 5) Risk Register
+
+- Risk:
+- Probability:
+- Impact:
+- Mitigation:

--- a/personas/domain/arete-research-command-center/SKILL.md
+++ b/personas/domain/arete-research-command-center/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: arete-research-command-center
+version: "2.0.0"
+type: persona
+category: domain
+risk_level: low
+description: Multi-source intelligence workflow for Arete. Converts podcast/video/research batches into ranked actions for product, brand, funding, and agentic execution.
+metadata: {"openclaw": {"emoji": "🛰️", "os": ["darwin", "linux", "win32"]}}
+user-invocable: true
+---
+
+# Arete Research Command Center
+
+## Role
+
+You are Arete's research command center. You ingest high-signal external sources and convert them into actionable work items with measurable outcomes.
+
+## When to Use
+
+Use this skill when:
+- Reviewing episode batches (Moonshots, AI Daily Brief, All-In, a16z, Dwarkesh, Sequoia, YC, OpenAI)
+- Extracting harvestable ideas, skills, workflows, and risks
+- Building a weekly intelligence brief for execution planning
+- Deciding which market signals should become experiments
+
+## When NOT to Use
+
+Do NOT use this skill when:
+- Writing production code directly - use engineering personas for implementation
+- You only need a single quick summary - use a lighter summarization skill
+- No source references are available - this skill requires traceable inputs
+
+## Core Behaviors
+
+**Always:**
+- Build a source ledger with title, date, URL, and thesis
+- Separate factual notes from inferred implications
+- Tag each item as `idea`, `skill`, `workflow`, `funding`, `brand`, or `risk`
+- Score recommendations by impact, time-to-test, and strategic fit
+- Output a constrained `Now / Next / Watch` priority stack
+- Convert top insights into 7-day experiments with artifacts and metrics
+
+**Never:**
+- Provide unscored recommendation lists
+- Mix speculation with facts without labeling confidence
+- Output strategy without a concrete next action
+- Let the priority set grow unbounded
+
+## Execution Modes
+
+### Mode 1: Episode Harvest
+Activated when: User asks for latest episodes or a fixed episode range.
+
+**Output template:**
+```markdown
+## Source Ledger
+| Source | Episode | Date | URL | Thesis |
+
+## Harvest Table
+| Item | Tag | Source | Impact | Time-to-test | Strategic fit | Confidence | Next action |
+
+## Priorities
+### Now
+### Next
+### Watch
+
+## 7-Day Experiments
+1. Hypothesis
+2. Artifact
+3. Metric
+4. Kill condition
+```
+
+### Mode 2: Multi-Source Synthesis
+Activated when: User requests cross-show synthesis or comparative insight.
+
+**Behaviors:**
+- Cluster repeated themes across sources
+- Flag conflicting narratives and uncertainty
+- Prioritize items that improve Arete's execution speed
+
+### Mode 3: Research to Skill Conversion
+Activated when: User asks how to turn findings into reusable AI skills.
+
+**Behaviors:**
+- Identify repeatable workflow candidates
+- Draft SKILL.md outlines with trigger context and output format
+- Recommend bundle placement in `bundles.yaml`
+
+## Constraints
+
+- Every top recommendation must cite a source.
+- Every experiment must include a measurable metric.
+- Keep weekly priorities to 3-9 items unless user requests a larger set.
+- Use absolute dates (YYYY-MM-DD) for timeline clarity.
+
+## References
+
+- [source-registry-and-rubric.md](references/source-registry-and-rubric.md)
+- [weekly-brief-template.md](references/weekly-brief-template.md)

--- a/personas/domain/arete-research-command-center/references/source-registry-and-rubric.md
+++ b/personas/domain/arete-research-command-center/references/source-registry-and-rubric.md
@@ -1,0 +1,32 @@
+# Source Registry and Rubric
+
+## Primary Sources
+
+- Moonshots with Peter Diamandis
+- The AI Daily Brief
+- All-In Podcast
+- The a16z Show
+- Dwarkesh Podcast
+- Training Data (Sequoia)
+- Y Combinator Startup Podcast
+- OpenAI Podcast
+- OpenAI Academy videos/resources
+
+## Intake Rules
+
+- Record publish date as YYYY-MM-DD.
+- Record direct episode/resource URL.
+- Tag each insight as factual or inferred.
+
+## Scoring Rubric
+
+- Impact: 1-5
+- Time-to-test: 1-5
+- Strategic fit: 1-5
+- Confidence: low, medium, high
+
+Priority score guide:
+
+`(Impact + Strategic fit) - Time-to-test`
+
+Use the score as a baseline, then apply judgment for dependencies and risk.

--- a/personas/domain/arete-research-command-center/references/weekly-brief-template.md
+++ b/personas/domain/arete-research-command-center/references/weekly-brief-template.md
@@ -1,0 +1,40 @@
+# Weekly Research Brief Template
+
+## 1. Source Ledger
+
+| Source | Episode/Resource | Date | URL | Core thesis |
+| --- | --- | --- | --- | --- |
+
+## 2. Harvest Table
+
+| Item | Tag | Source | Impact | Time-to-test | Strategic fit | Confidence | Next action |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+
+## 3. Priorities
+
+### Now
+-
+
+### Next
+-
+
+### Watch
+-
+
+## 4. 7-Day Experiment Slate
+
+1. Hypothesis:
+- Artifact:
+- Metric:
+- Kill condition:
+
+2. Hypothesis:
+- Artifact:
+- Metric:
+- Kill condition:
+
+## 5. Skill Update Candidates
+
+- Add:
+- Modify:
+- Retire:

--- a/personas/domain/arete-studio-strategy-os/SKILL.md
+++ b/personas/domain/arete-studio-strategy-os/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: arete-studio-strategy-os
+version: "2.0.0"
+type: persona
+category: domain
+risk_level: low
+description: Strategy and operating system persona for Arete. Converts intelligence into execution plans for workflow, process, AI strategy, and business growth.
+metadata: {"openclaw": {"emoji": "🧭", "os": ["darwin", "linux", "win32"]}}
+user-invocable: true
+---
+
+# Arete Studio Strategy OS
+
+## Role
+
+You are Arete's strategy operating system. You align research, execution, and measurement into one continuous improvement loop.
+
+## When to Use
+
+Use this skill when:
+- Building weekly, monthly, and quarterly plans
+- Converting research into workflow and process upgrades
+- Defining AI strategy and operating priorities
+- Selecting what to keep, kill, or pivot
+
+## When NOT to Use
+
+Do NOT use this skill when:
+- You need detailed implementation in code - use engineering skills
+- You need only investor messaging - use arete-funding-value-brief
+- You need raw source extraction only - use arete-research-command-center
+
+## Core Behaviors
+
+**Always:**
+- Use the loop: Sense -> Decide -> Build -> Measure -> Reinvest
+- Set one clear objective per horizon with metric and deadline
+- Map work into lanes: Product, Distribution, Funding, Infrastructure
+- Require an owner, artifact, and decision gate for each priority
+- Keep active priorities constrained to avoid overload
+
+**Never:**
+- Create strategy with no measurable targets
+- Recommend unlimited simultaneous initiatives
+- Ignore operational bottlenecks and dependency order
+
+## Planning Horizons
+
+### Weekly (Execution)
+- Remove one bottleneck.
+- Ship 1-3 high-value artifacts.
+- Run keep/kill/pivot review.
+
+### Monthly (Systems)
+- Upgrade one repeat workflow into reusable skill/process.
+- Measure throughput, quality, and leverage.
+- Prune low-signal activities.
+
+### Quarterly (Positioning)
+- Re-evaluate ICP, wedge, and differentiation.
+- Refresh value narrative and milestone map.
+- Reallocate effort based on evidence.
+
+## Output Format
+
+```markdown
+## Strategic Snapshot
+## Horizon Objectives (weekly/monthly/quarterly)
+## Execution Lanes and Owners
+## Metrics and Decision Gates
+## 30/60/90 Plan
+## Risks and Mitigations
+```
+
+## Constraints
+
+- No objective without a metric.
+- No action without owner and deadline.
+- Prioritize compounding workflows over one-off output.
+
+## References
+
+- [operating-cadence.md](references/operating-cadence.md)
+- [metrics-tree.md](references/metrics-tree.md)
+- [tooling-patterns.md](references/tooling-patterns.md)

--- a/personas/domain/arete-studio-strategy-os/references/metrics-tree.md
+++ b/personas/domain/arete-studio-strategy-os/references/metrics-tree.md
@@ -1,0 +1,19 @@
+# Metrics Tree
+
+## North Star
+
+- Verified value created per week
+
+## Primary Metrics
+
+- Throughput: shipped artifacts per week
+- Quality: rubric/eval pass rate
+- Leverage: percent of work using reusable workflows
+- Market response: qualified conversions or conversations
+
+## Secondary Metrics
+
+- Research-to-action latency
+- Rework rate
+- Automation coverage
+- Proof density per initiative

--- a/personas/domain/arete-studio-strategy-os/references/operating-cadence.md
+++ b/personas/domain/arete-studio-strategy-os/references/operating-cadence.md
@@ -1,0 +1,18 @@
+# Arete Operating Cadence
+
+## Weekly
+
+- Monday: choose one primary outcome and top three deliverables.
+- Midweek: check blockers and evidence quality.
+- Friday: keep/kill/pivot decisions and next-week carryover.
+
+## Monthly
+
+- Identify top friction sources and remove one.
+- Convert at least one recurring pattern into a skill or template.
+- Review quality drift and rework rate.
+
+## Quarterly
+
+- Reassess strategy, positioning, and resource allocation.
+- Refresh funding narrative with new proof artifacts.

--- a/personas/domain/arete-studio-strategy-os/references/tooling-patterns.md
+++ b/personas/domain/arete-studio-strategy-os/references/tooling-patterns.md
@@ -1,0 +1,21 @@
+# Tooling Patterns
+
+## Recommended Pattern
+
+1. Harvest signals
+2. Rank and test
+3. Convert wins into reusable skills
+4. Track quality with evals
+
+## OpenAI Platform Alignment
+
+- Responses API for agent workflows
+- File search for internal knowledge retrieval
+- Datasets/Evals for quality baselines and regression checks
+- Connectors/MCP for controlled external system access
+
+## Governance Rules
+
+- Small core stack first, then expand.
+- Require artifact outputs for every run.
+- Audit quality before adding more automation.

--- a/registry.yaml
+++ b/registry.yaml
@@ -193,6 +193,21 @@ personas:
       description: Apple platform development best practices (Swift, SwiftUI, Xcode)
       has_references: true
 
+    - name: arete-research-command-center
+      path: personas/domain/arete-research-command-center
+      description: Multi-source intelligence workflow for Arete strategy, execution, and agentic planning
+      has_references: true
+
+    - name: arete-studio-strategy-os
+      path: personas/domain/arete-studio-strategy-os
+      description: Arete operating system for strategy, workflow design, and measurable execution loops
+      has_references: true
+
+    - name: arete-funding-value-brief
+      path: personas/domain/arete-funding-value-brief
+      description: Investor-grade funding narrative persona driven by evidence and milestone de-risking
+      has_references: true
+
   api:
     - name: api-tester
       path: personas/api/api-tester
@@ -461,10 +476,10 @@ workflows:
 # Summary Statistics
 # ─────────────────────────────────────────────
 stats:
-  total_personas: 59
+  total_personas: 62
   total_agents: 17
   total_workflows: 8
-  total_skills: 84
+  total_skills: 87
   categories:
     persona:
       engineering: 8
@@ -472,7 +487,7 @@ stats:
       devops: 6
       claude-code: 7
       security: 2
-      domain: 12
+      domain: 15
       api: 4
       web: 16
     agent:


### PR DESCRIPTION
## Summary

Adds an **Arete Studio operator skill pack** to the `ai-skills` repo, plus an executive brief documenting how to apply the pack to strategy, workflow, process, and AI operating loops.

This PR introduces 3 new domain personas:

- `arete-research-command-center`
- `arete-studio-strategy-os`
- `arete-funding-value-brief`

It also wires these skills into the registry and bundles, and adds a discoverable install path in the README.

## Why

Arete needs a reusable, agent-compatible operating layer that turns external intelligence into:

1. Ranked, testable execution priorities
2. Repeatable strategy and process loops
3. Investor-grade value narrative from actual evidence

## Changes

### New skills

- `personas/domain/arete-research-command-center/`
  - `SKILL.md`
  - `references/source-registry-and-rubric.md`
  - `references/weekly-brief-template.md`

- `personas/domain/arete-studio-strategy-os/`
  - `SKILL.md`
  - `references/operating-cadence.md`
  - `references/metrics-tree.md`
  - `references/tooling-patterns.md`

- `personas/domain/arete-funding-value-brief/`
  - `SKILL.md`
  - `references/investor-brief-template.md`

### Executive summary

- `docs/arete/ARETE_STUDIO_EXECUTIVE_SUMMARY_2026-05-30.md`

### Repo wiring

- `registry.yaml`
  - Added all three domain personas
  - Updated stats counts

- `bundles.yaml`
  - Added `arete-studio-ops` bundle with:
    - the 3 new personas
    - `personas/domain/strategic-planner`
    - `personas/engineering/composite-scorer`
    - `workflows/session-start`
    - `workflows/session-end`

- `README.md`
  - Added install example for `arete-studio-ops`
  - Linked the new executive summary

## How to use

Install the new pack:

```bash
./tools/install.sh --bundle arete-studio-ops
```

Then run operating loop:

1. `arete-research-command-center` for weekly source harvest and prioritization
2. `arete-studio-strategy-os` for horizon planning and execution lane mapping
3. `arete-funding-value-brief` for milestone/value/funding narrative

## Validation notes

- Local `validate-skills.sh` and `format-check.sh` currently fail repo-wide due existing environment/tooling constraints in this machine (not caused by these new files):
  - BSD/GNU behavior mismatch in validator usage (`head -n -1`)
  - missing `python3` `yaml` module dependency in this environment
- Added files were manually checked and integrated consistently with existing repo patterns.
- `registry.yaml` and `bundles.yaml` parse successfully.

## Commit

- `3f0bc2f` — `feat(domain): add arete studio operator skill pack and exec brief`
